### PR TITLE
画像保存時に配信されるパス名をDBに保存した

### DIFF
--- a/lib/server/nextPublicUrl.ts
+++ b/lib/server/nextPublicUrl.ts
@@ -1,0 +1,4 @@
+export const nextPublicUrl = (url: string): string => {
+  if (!(process.env.NODE_ENV === 'development')) return url
+  return url.replace(/^public\//, '')
+}

--- a/pages/api/me/icon.ts
+++ b/pages/api/me/icon.ts
@@ -6,6 +6,7 @@ import { initMiddleware } from '../../../lib/server/middleware/initMiddleware'
 import { createUploader } from '../../../lib/server/multer'
 import { NextApiRequestsWithFormData } from '../../../lib/server/type/NextApiRequestsWithFormData'
 import { loginCheck } from '../../../lib/server/middleware/loginCheck'
+import { nextPublicUrl } from '../../../lib/server/nextPublicUrl'
 
 export const config = {
   api: {
@@ -31,7 +32,7 @@ export default async function handler(
   if (req.method === 'PATCH') {
     const userDto: UserDto = {
       id: currentUser.id as number,
-      image: req.file.path,
+      image: nextPublicUrl(req.file.path),
     }
 
     const user = await updateUser(userDto)

--- a/pages/api/me/index.ts
+++ b/pages/api/me/index.ts
@@ -6,7 +6,6 @@ import { loginCheck } from '../../../lib/server/middleware/loginCheck'
 import { initMiddleware } from '../../../lib/server/middleware/initMiddleware'
 const loginCheckMiddleware = initMiddleware(loginCheck)
 
-
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,


### PR DESCRIPTION
development環境では画像を`public/uploads`以下にアップロードしているが、そのままではnextjsのサーバー上ではpulicが取り除かれたパスで配信されてしまうので、配信されるはずのパス名をDBに保存することにした